### PR TITLE
Change the fallback for advertised.host.name

### DIFF
--- a/scripts/confluent-start.sh
+++ b/scripts/confluent-start.sh
@@ -4,7 +4,7 @@ mkdir /logs &> /dev/null
 
 cd /confluent-2.0.0
 
-_IP=$(cat /etc/hosts | head -n1 | awk '{print $1}')
+_IP=$(hostname -i | awk '{print $1}')
 
 _KAFKA_DATA_DIR=/kafka-logs
 


### PR DESCRIPTION
127.0.0.1 is not an acceptable fallback for the advertised.host.name, because it wont be accessible from outside of the container. Using the IP of eth0 might be a better alternative.
